### PR TITLE
Updating the version number for WP 6.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Change log
 
+## [[1.2.8]](https://github.com/lightspeeddevelopment/lsx-give-payfast-gateway/releases/tag/1.2.8) - 2023-08-09
+
+### Security
+- General testing to ensure compatibility with latest WordPress version (6.3).
+- General testing to ensure compatibility with latest Give - Donation Plugin version (2.31.0).
+- General testing to ensure compatibility with latest Give - Recurring Donations (1.12.2).
+
 ## [[1.2.7]](https://github.com/lightspeeddevelopment/lsx-give-payfast-gateway/releases/tag/1.2.7) - 2023-04-20
 
 ### Security

--- a/give-payfast.php
+++ b/give-payfast.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://www.lsdev.biz/product/givewp-payfast-integration-addon/
  * Description: The LSX PayFast Gateway for GiveWP is the only way to use the powerful Give plugin for WordPress to accept Rands in South Africa. Give is a flexible, robust, and simple WordPress plugin for accepting donations directly on your website.
  * Author: LightSpeed
- * Version: 1.2.7
+ * Version: 1.2.8
  * Author URI: https://www.lsdev.biz/products/
  * License: GPL3+
  * Text Domain: payfast_give

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === LSX PayFast Gateway for Give ===
 Tags: lsx, payment gateway, payfast, givewp, donations
 Requires at least: 5.3
-Tested up to: 6.2
-Stable tag: 1.2.7
+Tested up to: 6.3
+Stable tag: 1.2.8
 Contributors: feedmymedia
 License: GPL3+
 License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
### Security
- General testing to ensure compatibility with latest WordPress version (6.3).
- General testing to ensure compatibility with latest Give - Donation Plugin version (2.31.0).
- General testing to ensure compatibility with latest Give - Recurring Donations (1.12.2).